### PR TITLE
Fix defaultChecked usage in canon Checkbox

### DIFF
--- a/packages/canon/src/components/Checkbox/Checkbox.tsx
+++ b/packages/canon/src/components/Checkbox/Checkbox.tsx
@@ -26,6 +26,7 @@ export const Checkbox = React.forwardRef<HTMLButtonElement, CheckboxProps>(
     const {
       label,
       checked,
+      defaultChecked,
       onChange,
       disabled,
       required,
@@ -40,6 +41,7 @@ export const Checkbox = React.forwardRef<HTMLButtonElement, CheckboxProps>(
         ref={ref}
         className={clsx('canon-CheckboxRoot', className)}
         checked={checked}
+        defaultChecked={defaultChecked}
         onCheckedChange={onChange}
         disabled={disabled}
         required={required}


### PR DESCRIPTION
## Summary
- use the `defaultChecked` prop in `<Checkbox>` so uncontrolled mode works as intended

## Testing
- `yarn --cwd packages/canon test` *(fails: request was cancelled due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_683fff7c37488331be178b9ffdf6afce